### PR TITLE
Updated Dockerfile and patch files for current libyaul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -234,6 +234,8 @@ ENV INSTALL_YAUL_SAMPLES=0
 
 ENV SEGASGL=${SATURN_SGL}
 
+WORKDIR "${SATURN_TMP}"
+
 COPY Resources/dl-sgl302.sh $SATURN_TMP
 RUN $SATURN_TMP/dl-sgl302.sh
 COPY Resources/build-sgl302.sh $SATURN_TMP
@@ -307,6 +309,7 @@ COPY Resources/yaul/pre.common.mk "$SATURN_TMP/yaul/libyaul/common/"
 COPY Resources/yaul/Makefile "$SATURN_TMP/yaul"
 COPY Resources/yaul/tools/bin2o "$SATURN_TMP/yaul/tools/bin2o/"
 COPY Resources/yaul/tools/make-ip "$SATURN_TMP/yaul/tools/make-ip/"
+COPY Resources/yaul/tools/Makefile "$SATURN_TMP/yaul/tools/Makefile"
 COPY Resources/yaul/common/specs/* "$SATURN_TMP/yaul/libyaul/common/specs/"
 COPY Resources/yaul/common/specs/* "$SATURN_TMP/yaul/libyaul/common/specs/"
 COPY Resources/yaul/common/ldscripts/yaul.x "$SATURN_TMP/yaul/libyaul/common/ldscripts/"

--- a/Resources/yaul/Makefile
+++ b/Resources/yaul/Makefile
@@ -2,7 +2,7 @@ PROJECTS:= \
 	libyaul \
 	libtga \
 	libbcl \
-	libsega3d
+	libg3d
 
 include env.mk
 

--- a/Resources/yaul/common/ldscripts/yaul.x
+++ b/Resources/yaul/common/ldscripts/yaul.x
@@ -35,16 +35,24 @@ SECTIONS
      *(.gnu.linkonce.t.*)
 
      . = ALIGN (0x10);
+     __CTOR_SECTION__ = .;
+     KEEP (*(.ctor))
+     SHORT (0x000B) /* RTS */
+     SHORT (0x0009) /* NOP */
+
+     . = ALIGN (0x10);
      __INIT_SECTION__ = .;
      KEEP (*(.init))
+
+     . = ALIGN (0x10);
+     __DTOR_SECTION__ = .;
+     KEEP (*(.dtor))
      SHORT (0x000B) /* RTS */
      SHORT (0x0009) /* NOP */
 
      . = ALIGN (0x10);
      __FINI_SECTION__ = .;
      KEEP (*(.fini))
-     SHORT (0x000B) /* RTS */
-     SHORT (0x0009) /* NOP */
 
      . = ALIGN (0x10);
      __CTOR_LIST__ = .;
@@ -126,6 +134,7 @@ SECTIONS
   {
      PROVIDE_HIDDEN (__uncached_start = .);
      *(.uncached)
+     *(.uncached.*)
      . = ALIGN (0x10);
      PROVIDE_HIDDEN (__uncached_end = .);
   }

--- a/Resources/yaul/common/specs/yaul.specs
+++ b/Resources/yaul/common/specs/yaul.specs
@@ -10,7 +10,7 @@
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include)) \
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/bcl)) \
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/tga)) \
--I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/sega3d)) \
+-I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/g3d)) \
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/yaul)) \
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/yaul/common)) \
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/yaul/dbgio)) \
@@ -20,6 +20,7 @@
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/yaul/scu)) \
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/yaul/scu/bus/a/cs0/arp)) \
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/yaul/scu/bus/a/cs0/dram-cart)) \
+-I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/yaul/scu/bus/a/cs0/flash)) \
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/yaul/scu/bus/a/cs0/usb-cart)) \
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/yaul/scu/bus/a/cs2/cd-block)) \
 -I%:getenv(YAUL_INSTALL_ROOT /%:getenv(YAUL_ARCH_SH_PREFIX /include/yaul/scu/bus/b/scsp)) \
@@ -38,6 +39,9 @@
 -fomit-frame-pointer \
 -ffast-math \
 -fstrict-aliasing \
+-flto \
+-ffunction-sections \
+-fdata-sections \
 %(includes)
 
 %rename cc1plus old_cc1plus

--- a/Resources/yaul/pre.common.mk
+++ b/Resources/yaul/pre.common.mk
@@ -139,11 +139,13 @@ SH_CFLAGS= \
 	-Wstrict-aliasing \
 	-Wno-main \
 	-Wno-format \
+	-save-temps=obj \
 	-DHAVE_DEV_CARTRIDGE=$(YAUL_OPTION_DEV_CARTRIDGE) \
 	-DHAVE_GDB_SUPPORT=$(YAUL_OPTION_BUILD_GDB) \
 	-DHAVE_ASSERT_SUPPORT=$(YAUL_OPTION_BUILD_ASSERT)
 
 SH_LDFLAGS= \
+	-Wl,--gc-sections \
 	-Wl,-Map,$(SH_BUILD_PATH)/$(SH_PROGRAM).map
 
 SH_CXXFLAGS= $(SH_CFLAGS)

--- a/Resources/yaul/tools/Makefile
+++ b/Resources/yaul/tools/Makefile
@@ -1,0 +1,25 @@
+PROJECTS:= \
+	bin2c \
+	bin2o \
+	make-cue \
+	make-iso \
+	make-ip
+
+include ../env.mk
+
+# XXX: Currently, gdb-ftdi-proxy is broken under Windows
+ifneq ($(OS), Windows_NT)
+ifeq ($(strip $(BUILD_CROSS)),)
+#PROJECTS+= \
+	gdb-ftdi-proxy
+endif
+endif
+
+.PHONY: all clean distclean install
+
+all clean distclean install:
+	$(ECHO)mkdir -p $(YAUL_BUILD_ROOT)/$(YAUL_BUILD)
+	$(ECHO)for tool in $(PROJECTS); do \
+		printf -- "$(V_BEGIN_CYAN)tools $${tool}$(V_END) $(V_BEGIN_GREEN)$@$(V_END)\n"; \
+		($(MAKE) -C $${tool} $@) || exit $${?}; \
+	done


### PR DESCRIPTION
YAUL added new headers and changed names for some bits
One difference still between the libyaul tools and the tools in this PR is that the ftdi-dependent parts of the setup are disabled