### PR TITLE
fix: at spr_3c in spr_3c.c

### DIFF
--- a/Resources/sbl6/segalib/spr/spr_3c.c
+++ b/Resources/sbl6/segalib/spr/spr_3c.c
@@ -1253,8 +1253,10 @@ transCluster(SprCluster *cluster)
 	    if((obj->dispFlag & SHADING_MASK) == GOURAUD_SHADING) {
                 if(obj->dispFlag & INBETWEEN_OBJECT) {
   	            polyTransParm.gourVertCount = 0;
-  	            memcpy(cBuf->vertBright,obj->vertNormal,
-  	                                  obj->vertCount*sizeof(Sint32));
+  	            if(obj->vertCount > 0 &&
+  	               (Uint32)obj->vertCount <= polyTransParm.transViewVertCount)
+  	                memcpy(cBuf->vertBright,obj->vertNormal,
+  	                                  (Uint32)obj->vertCount*sizeof(Sint32));
                 } else {
 	            polyTransParm.gourVertCount = obj->vertCount;
 	            polyTransParm.vertNormal    = obj->vertNormal;


### PR DESCRIPTION
## Summary
Fix high severity security issue in `Resources/sbl6/segalib/spr/spr_3c.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `Resources/sbl6/segalib/spr/spr_3c.c:1256` |

**Description**: At spr_3c.c line 1256, memcpy copies vertex normal data from obj->vertNormal into cBuf->vertBright without an explicit bounds check. If the source array (obj->vertNormal) contains more elements than the destination buffer (cBuf->vertBright) can hold, adjacent heap memory is overwritten. This is a classic CWE-120/CWE-787 pattern in a C rendering library that processes external asset data. The copy size appears to be derived from the object structure itself, meaning a crafted asset with an inflated vertex count directly controls the overflow magnitude.

## Changes
- `Resources/sbl6/segalib/spr/spr_3c.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
